### PR TITLE
fix: autoloaderとPlayer生成時のエラーを一時対応

### DIFF
--- a/src/lib/black_jack/Application/Game.php
+++ b/src/lib/black_jack/Application/Game.php
@@ -6,6 +6,7 @@ use BlackJack\Domain\Deck;
 use BlackJack\Domain\Dealer;
 use BlackJack\Domain\PointCalculator;
 use BlackJack\Support\PokerOutput;
+use BlackJack\Support\PlayerFactory;
 use BlackJack\Application\GameProcess;
 
 class Game

--- a/src/lib/black_jack/Application/Game.php
+++ b/src/lib/black_jack/Application/Game.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace BlackJack;
+namespace BlackJack\Application;
 
-use BlackJack\Deck;
-use BlackJack\Dealer;
-use BlackJack\PointCalculator;
-use BlackJack\PokerOutput;
-use BlackJack\GameProcess;
+use BlackJack\Domain\Deck;
+use BlackJack\Domain\Dealer;
+use BlackJack\Domain\PointCalculator;
+use BlackJack\Support\PokerOutput;
+use BlackJack\Application\GameProcess;
 
 class Game
 {
@@ -19,8 +19,7 @@ class Game
         public PokerOutput $pokerOutPut,
         public PlayerFactory $playerFactory,
         public array $playerNames
-    ) {
-    }
+    ) {}
 
     const CONTROL_PLAYER_NUMBER = 0;
     public function start(): string
@@ -53,8 +52,7 @@ class Game
         }
         // 現在のスコアを出力
         $this->pokerOutPut->displayDealerScore($dealerScore);
-        echo PHP_EOL;
-        ;
+        echo PHP_EOL;;
 
         // 勝敗の判定
         $this->gameProcess->judgeWinner($playerResult, $dealerScore, $this->playerNames);

--- a/src/lib/black_jack/Application/GameProcess.php
+++ b/src/lib/black_jack/Application/GameProcess.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace BlackJack;
+namespace BlackJack\Application;
 
-use BlackJack\Dealer;
-use BlackJack\Deck;
-use BlackJack\Player;
-use BlackJack\PointCalculator;
-use BlackJack\PokerOutput;
+use BlackJack\Domain\Dealer;
+use BlackJack\Domain\Deck;
+use BlackJack\Domain\Player;
+use BlackJack\Domain\PointCalculator;
+use BlackJack\Support\PokerOutput;
 
 class GameProcess
 {
@@ -41,7 +41,8 @@ class GameProcess
     }
 
     // バースト判定
-    public function isBurst(int $score): bool {
+    public function isBurst(int $score): bool
+    {
         if ($score > 21) {
             return true;
         }
@@ -53,7 +54,7 @@ class GameProcess
     {
         // バースト判定　バーストであれば、trueを受け取る
         $isBurnOut = $this->isBurst($dealerScore);
-        if($isBurnOut) {
+        if ($isBurnOut) {
             $this->pokerOutput->displayDealerBurstMessage();
             return true;
         }
@@ -77,7 +78,7 @@ class GameProcess
         }
         return $dealerScore;
     }
-    
+
     // ディーラーのカード取得
     public function processDealerTurn(array $hands): int
     {

--- a/src/lib/black_jack/Application/StartGame.php
+++ b/src/lib/black_jack/Application/StartGame.php
@@ -1,16 +1,17 @@
 <?php
 
-namespace BlackJack;
+namespace BlackJack\Application;
 
-require dirname(__DIR__, 3) . '/vendor/autoload.php';
-use BlackJack\Card;
-use BlackJack\Deck;
-use BlackJack\Dealer;
-use BlackJack\Game;
-use BlackJack\GameProcess;
-use BlackJack\PokerOutput;
-use BlackJack\PointCalculator;
-use BlackJack\PlayerFactory;
+require dirname(__DIR__, 3) . "/vendor/autoload.php";
+
+use BlackJack\Domain\Card;
+use BlackJack\Domain\Deck;
+use BlackJack\Domain\Dealer;
+use BlackJack\Application\Game;
+use BlackJack\Application\GameProcess;
+use BlackJack\Support\PokerOutput;
+use BlackJack\Domain\PointCalculator;
+use BlackJack\Support\PlayerFactory;
 
 $players = ['takuya', 'toki', 'asuka'];
 $card = new Card();

--- a/src/lib/black_jack/Domain/Card.php
+++ b/src/lib/black_jack/Domain/Card.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace BlackJack;
+namespace BlackJack\Domain;
 
 class Card
 {
+
     public $cards = [];
     public function __construct()
     {

--- a/src/lib/black_jack/Domain/Dealer.php
+++ b/src/lib/black_jack/Domain/Dealer.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace BlackJack;
+namespace BlackJack\Domain;
 
-use BlackJack\Deck;
+use BlackJack\Domain\Deck;
 
 class Dealer
 {
@@ -10,15 +10,13 @@ class Dealer
     private const ADD_CARD_NUMBER = 1;
 
     public array $dealerCard = [];
-    public function __construct (private Deck $deck)
-    {
-    }
+    public function __construct(private Deck $deck) {}
 
     public function dealStartHands(): array
     {
         return $this->deck->drawCard(self::FIRST_CARD_NUMBER);
     }
-    
+
     public function dealAddCard(): array
     {
         return $this->deck->drawCard(self::ADD_CARD_NUMBER);

--- a/src/lib/black_jack/Domain/Deck.php
+++ b/src/lib/black_jack/Domain/Deck.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace BlackJack;
+namespace BlackJack\Domain;
 
-use BlackJack\Card;
+use BlackJack\Domain\Card;
 
 class Deck
 {

--- a/src/lib/black_jack/Domain/NomalCpu.php
+++ b/src/lib/black_jack/Domain/NomalCpu.php
@@ -1,8 +1,5 @@
 <?php
 
-namespace BlackJack;
+namespace BlackJack\Domain;
 
-class NormalCpu
-{
-
-}
+class NormalCpu {}

--- a/src/lib/black_jack/Domain/Player.php
+++ b/src/lib/black_jack/Domain/Player.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace BlackJack;
+namespace BlackJack\Domain;
 
-use BlackJack\Dealer;
+use BlackJack\Domain\Dealer;
 
 class Player
 {
@@ -10,9 +10,7 @@ class Player
     public function __construct(
         public Dealer $dealer,
         public string $playerName
-        )
-    {
-    }
+    ) {}
 
     //手札取得処理の変更に対応させる、また、手札プロパティ変更を防止の為、メソッドを通して手札情報を取得。
     public function getHand(): array

--- a/src/lib/black_jack/Domain/PointCalculator.php
+++ b/src/lib/black_jack/Domain/PointCalculator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace BlackJack;
+namespace BlackJack\Domain;
 
 class PointCalculator
 {

--- a/src/lib/black_jack/Domain/StrongCpu.php
+++ b/src/lib/black_jack/Domain/StrongCpu.php
@@ -1,8 +1,5 @@
 <?php
 
-namespace BlackJack;
+namespace BlackJack\Domain;
 
-class StrongCpu
-{
-
-}
+class StrongCpu {}

--- a/src/lib/black_jack/Support/PlayerFactory.php
+++ b/src/lib/black_jack/Support/PlayerFactory.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace BlackJack;
+namespace BlackJack\Support;
 
-use BlackJack\Dealer;
-use BlackJack\Deck;
-use BlackJack\Player;
-use BlackJack\StrongCpu;
-use BlackJack\NormalCpu;
+use BlackJack\Domain\Dealer;
+use BlackJack\Domain\Deck;
+use BlackJack\Domain\Player;
+use BlackJack\Domain\StrongCpu;
+use BlackJack\Domain\NormalCpu;
 
 class PlayerFactory
 {

--- a/src/lib/black_jack/Support/PlayerFactory.php
+++ b/src/lib/black_jack/Support/PlayerFactory.php
@@ -18,14 +18,14 @@ class PlayerFactory
         // 文字列(例'Player')の場合、名前空間が識別できずエラーになる場合があるため、::class(完全修飾クラス名)を使用
         $infos = [
             ['name' => $playerNames[0], 'className' => Player::class],
-            ['name' => $playerNames[1], 'className' => StrongCpu::class],
-            ['name' => $playerNames[2], 'className' => NormalCpu::class]
+            // ['name' => $playerNames[1], 'className' => StrongCpu::class],
+            // ['name' => $playerNames[2], 'className' => NormalCpu::class]
         ];
 
         foreach ($infos as $info) {
             $name = $info['name'];
             $className = $info['className'];
-            $this->players[$name] = new $className($dealer);
+            $this->players[$name] = new $className($dealer, $name);
         }
     }
 }

--- a/src/lib/black_jack/Support/PokerOutput.php
+++ b/src/lib/black_jack/Support/PokerOutput.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace BlackJack;
+namespace BlackJack\Support;
 
 class PokerOutput
 {


### PR DESCRIPTION
以下のエラーを解消するための一時対応を行いました：

- autoloader がクラスファイルを見つけられないエラーを修正
- プレイヤー生成時、PlayerFactory クラスが見つからないエラーを修正
- CPU クラス未実装によるエラーを回避（該当行をコメントアウト）
- $className 呼び出し時に $name 引数を追加して引数不足を解消

※ StrongCpu / NormalCpu は未実装のため、後日改修予定
